### PR TITLE
feat(backend): switch Socrata default to active Seattle Channel dataset

### DIFF
--- a/backend/town_pulse/settings.py
+++ b/backend/town_pulse/settings.py
@@ -128,9 +128,13 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Seattle Socrata (data.seattle.gov) — civic events source.
-# Default dataset is "Special Events Permits" (dm95-f8w5). Override
-# SEATTLE_SOCRATA_DATASET_ID to point at a different dataset if needed.
+# Default dataset is "Seattle Channel TV Schedule" (6853-bgsc), which is
+# actively maintained and carries council meetings, city briefings, and
+# community programming with upcoming dates. Override SEATTLE_SOCRATA_DATASET_ID
+# (and SEATTLE_SOCRATA_DATE_FIELD if the new dataset uses a different date
+# column) to point at a different dataset.
 # SEATTLE_SOCRATA_APP_TOKEN is optional; unauthenticated requests are throttled.
 SEATTLE_SOCRATA_DOMAIN = os.environ.get('SEATTLE_SOCRATA_DOMAIN', 'data.seattle.gov')
-SEATTLE_SOCRATA_DATASET_ID = os.environ.get('SEATTLE_SOCRATA_DATASET_ID', 'dm95-f8w5')
+SEATTLE_SOCRATA_DATASET_ID = os.environ.get('SEATTLE_SOCRATA_DATASET_ID', '6853-bgsc')
+SEATTLE_SOCRATA_DATE_FIELD = os.environ.get('SEATTLE_SOCRATA_DATE_FIELD', 'date')
 SEATTLE_SOCRATA_APP_TOKEN = os.environ.get('SEATTLE_SOCRATA_APP_TOKEN', '')

--- a/backend/townpulse_app/seattle_socrata.py
+++ b/backend/townpulse_app/seattle_socrata.py
@@ -5,8 +5,15 @@ https://dev.socrata.com/docs/queries/ to search civic event datasets.
 """
 from __future__ import annotations
 
+from datetime import date
+
 import requests
 from django.conf import settings
+
+# Socrata column name on the default dataset (6853-bgsc, Seattle Channel
+# TV Schedule). Override via SEATTLE_SOCRATA_DATE_FIELD if you point the
+# integration at a dataset that uses a different column.
+_DEFAULT_DATE_FIELD = "date"
 
 
 class SocrataError(Exception):
@@ -31,18 +38,24 @@ def _normalize(row: dict) -> dict:
     Field names vary by dataset. This tries the common columns used on
     data.seattle.gov event datasets and falls back to empty strings.
     """
-    title = row.get("event_name") or row.get("name_of_event") or row.get("name") or ""
-    description = row.get("event_description") or row.get("description") or ""
+    title = row.get("title") or row.get("event_name") or row.get("name_of_event") or row.get("name") or ""
+    description = row.get("notes") or row.get("event_description") or row.get("description") or ""
     category = row.get("event_category") or row.get("category") or row.get("type_of_event") or ""
-    address = (
+    address_val = (
         row.get("event_address")
         or row.get("event_location")
         or row.get("location")
         or row.get("address")
         or ""
     )
-    date = row.get("event_start_date") or row.get("start_date") or row.get("date") or ""
-    external_id = row.get(":id") or row.get("permit_number") or row.get("id") or ""
+    # Socrata "location" fields can be dicts ({type, coordinates}); stringify safely.
+    address = address_val if isinstance(address_val, str) else ""
+    date = row.get("date") or row.get("event_start_date") or row.get("start_date") or ""
+    # Append time-of-day if present (e.g. TV schedule has a separate time column).
+    time_of_day = row.get("time")
+    if date and time_of_day and "T00:00:00" in date:
+        date = f"{date[:10]}T{time_of_day}"
+    external_id = row.get(":id") or row.get("msn") or row.get("permit_number") or row.get("id") or ""
     return {
         "external_id": str(external_id),
         "source_api": "seattle_socrata",
@@ -54,15 +67,7 @@ def _normalize(row: dict) -> dict:
     }
 
 
-def search_events(query: str | None = None, limit: int = 25) -> list[dict]:
-    """Search the configured Seattle dataset for events.
-
-    `query` does a case-insensitive full-text search via Socrata's `$q`.
-    """
-    params: dict[str, str | int] = {"$limit": max(1, min(int(limit), 1000))}
-    if query:
-        params["$q"] = query
-
+def _fetch(params: dict) -> list[dict]:
     try:
         resp = requests.get(_resource_url(), params=params, headers=_headers(), timeout=10)
         resp.raise_for_status()
@@ -72,4 +77,38 @@ def search_events(query: str | None = None, limit: int = 25) -> list[dict]:
     rows = resp.json()
     if not isinstance(rows, list):
         raise SocrataError("Unexpected Socrata response shape")
+    return rows
+
+
+def search_events(query: str | None = None, limit: int = 25) -> list[dict]:
+    """Search the configured Seattle dataset, preferring upcoming events.
+
+    Queries for events whose date is today or later, ordered soonest first.
+    If none match (e.g. the dataset hasn't been updated recently), falls
+    back to the most recent past events ordered newest first so the UI
+    still has something to show. `query` does a case-insensitive full-text
+    search via Socrata's `$q`.
+    """
+    date_field = getattr(settings, "SEATTLE_SOCRATA_DATE_FIELD", _DEFAULT_DATE_FIELD)
+    capped_limit = max(1, min(int(limit), 1000))
+    today_iso = date.today().isoformat()
+
+    upcoming_params: dict[str, str | int] = {
+        "$limit": capped_limit,
+        "$where": f"{date_field} >= '{today_iso}T00:00:00'",
+        "$order": f"{date_field} ASC",
+    }
+    if query:
+        upcoming_params["$q"] = query
+
+    rows = _fetch(upcoming_params)
+    if not rows:
+        fallback_params: dict[str, str | int] = {
+            "$limit": capped_limit,
+            "$order": f"{date_field} DESC",
+        }
+        if query:
+            fallback_params["$q"] = query
+        rows = _fetch(fallback_params)
+
     return [_normalize(row) for row in rows]


### PR DESCRIPTION
## Summary
- The previous default Socrata dataset (`dm95-f8w5`, Special Events Permits) stopped receiving updates in late 2025, so upcoming-event queries were returning zero.
- Switches the default to `6853-bgsc` (Seattle Channel TV Schedule), which is actively maintained and carries council meetings, city briefings, and community programming with upcoming dates.
- Normalizer now handles the new schema (`title`, `notes`, `msn`, separate `time` column) and safely skips Socrata dict-typed `location` fields.
- Dataset id, date field, domain, and app token all remain env-overridable in `settings.py`.

## Test plan
- [ ] `curl "http://localhost:8000/api/seattle-events/?limit=5"` returns upcoming entries dated today or later, soonest first.
- [ ] Search UI at `http://localhost:5173/` shows today's schedule onward.
- [ ] Passing a query (`?q=council`) filters results via Socrata `$q`.
- [ ] Overriding `SEATTLE_SOCRATA_DATASET_ID` still works for pointing at a different dataset.