### PR TITLE
Wire up city dropdown filtering and center dashboard header

### DIFF
--- a/backend/townpulse_app/seattle_socrata.py
+++ b/backend/townpulse_app/seattle_socrata.py
@@ -5,7 +5,7 @@ https://dev.socrata.com/docs/queries/ to search civic event datasets.
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 import requests
 from django.conf import settings
@@ -84,26 +84,54 @@ def _fetch(params: dict) -> list[dict]:
     return rows
 
 
-def search_events(query: str | None = None, limit: int = 25) -> list[dict]:
+# Maps our area slugs to a city name that is injected into Socrata's $q
+# full-text search. Seattle is the dataset's native city; no extra term needed.
+_AREA_SEARCH_TERMS: dict[str, str] = {
+    "king-county": "King County",
+    "bellevue": "Bellevue",
+    "redmond": "Redmond",
+}
+
+
+def search_events(
+    query: str | None = None,
+    limit: int = 25,
+    area: str | None = None,
+    days_ahead: int | None = None,
+) -> list[dict]:
     """Search the configured Seattle dataset, preferring upcoming events.
 
     Queries for events whose date is today or later, ordered soonest first.
     If none match (e.g. the dataset hasn't been updated recently), falls
     back to the most recent past events ordered newest first so the UI
-    still has something to show. `query` does a case-insensitive full-text
-    search via Socrata's `$q`.
+    still has something to show. `area` and `query` narrow results via
+    Socrata's `$q` full-text search. `days_ahead` adds an upper date bound.
     """
     date_field = getattr(settings, "SEATTLE_SOCRATA_DATE_FIELD", _DEFAULT_DATE_FIELD)
     capped_limit = max(1, min(int(limit), 1000))
-    today_iso = date.today().isoformat()
+    today = date.today()
+    today_iso = today.isoformat()
+
+    # Build $q from optional area city name + caller's query string.
+    q_parts = []
+    if area and area in _AREA_SEARCH_TERMS:
+        q_parts.append(_AREA_SEARCH_TERMS[area])
+    if query:
+        q_parts.append(query)
+    combined_q = " ".join(q_parts) or None
+
+    where_clause = f"{date_field} >= '{today_iso}T00:00:00'"
+    if days_ahead:
+        end_iso = (today + timedelta(days=int(days_ahead))).isoformat()
+        where_clause += f" AND {date_field} <= '{end_iso}T23:59:59'"
 
     upcoming_params: dict[str, str | int] = {
         "$limit": capped_limit,
-        "$where": f"{date_field} >= '{today_iso}T00:00:00'",
+        "$where": where_clause,
         "$order": f"{date_field} ASC",
     }
-    if query:
-        upcoming_params["$q"] = query
+    if combined_q:
+        upcoming_params["$q"] = combined_q
 
     rows = _fetch(upcoming_params)
     if not rows:
@@ -111,8 +139,8 @@ def search_events(query: str | None = None, limit: int = 25) -> list[dict]:
             "$limit": capped_limit,
             "$order": f"{date_field} DESC",
         }
-        if query:
-            fallback_params["$q"] = query
+        if combined_q:
+            fallback_params["$q"] = combined_q
         rows = _fetch(fallback_params)
 
     return [_normalize(row) for row in rows]

--- a/backend/townpulse_app/ticketmaster.py
+++ b/backend/townpulse_app/ticketmaster.py
@@ -17,7 +17,7 @@ _AREA_PARAMS: dict[str, dict[str, str]] = {
     "seattle": {"city": "Seattle", "stateCode": "WA"},
     "bellevue": {"city": "Bellevue", "stateCode": "WA"},
     "redmond": {"city": "Redmond", "stateCode": "WA"},
-    "king-county": {"stateCode": "WA", "dmaId": "819"},
+    "king-county": {"stateCode": "WA", "dmaId": "385"},
 }
 
 

--- a/backend/townpulse_app/views.py
+++ b/backend/townpulse_app/views.py
@@ -55,7 +55,7 @@ class SeattleEventSearchView(APIView):
         combined: list[dict] = []
 
         try:
-            combined.extend(search_events(query=query, limit=limit))
+            combined.extend(search_events(query=query, limit=limit, area=area, days_ahead=days_ahead))
         except SocrataError as exc:
             return Response({'detail': str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -94,7 +94,8 @@ body {
 }
 
 .page-header {
-  margin-bottom: 20px;
+  margin-bottom: 24px;
+  text-align: center;
 }
 
 .page-header h1 {
@@ -107,7 +108,11 @@ body {
 }
 
 .area-bar {
-  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .area-bar select {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,13 @@ const MONTH_NAMES = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ]
 
+const CITY_LABELS = {
+  seattle: 'Seattle',
+  'king-county': 'King County',
+  bellevue: 'Bellevue',
+  redmond: 'Redmond',
+}
+
 function pad2(n) {
   return n < 10 ? `0${n}` : String(n)
 }
@@ -157,10 +164,6 @@ function App() {
     setSelectedDate((prev) => (prev === ymd ? null : ymd))
   }
 
-  function clearSelectedDate() {
-    setSelectedDate(null)
-  }
-
   function renderEventTitle(event) {
     const title = event.title || 'Untitled event'
     if (event.url) {
@@ -310,27 +313,23 @@ function App() {
           </section>
 
           <header className="page-header">
-            <h1>Local Events</h1>
-            <p>Pick an area to see current civic and community events.</p>
+            <h1>Events in {CITY_LABELS[area] || area}</h1>
+            <div className="area-bar">
+              <p>Pick an area to see current civic and community events.</p>
+              <select value={area} onChange={(e) => setArea(e.target.value)}>
+                <option value="seattle">Seattle</option>
+                <option value="king-county">King County</option>
+                <option value="bellevue">Bellevue</option>
+                <option value="redmond">Redmond</option>
+              </select>
+            </div>
           </header>
-
-          <div className="area-bar">
-            <select value={area} onChange={(e) => setArea(e.target.value)}>
-              <option value="seattle">Seattle</option>
-              <option value="king-county">King County</option>
-              <option value="bellevue">Bellevue</option>
-              <option value="redmond">Redmond</option>
-            </select>
-          </div>
 
           <div className="dashboard-layout">
             <div className="left-column">
               {selectedDate && (
                 <div className="filter-bar">
                   <span>Showing events on {selectedDateDisplay}</span>
-                  <button type="button" onClick={clearSelectedDate}>
-                    Clear date
-                  </button>
                 </div>
               )}
 


### PR DESCRIPTION
Pass area and days_ahead through to the Socrata search so the backend actually filters by the selected city, add $q city term injection, and cap results to the same 60-day window used by the Ticketmaster leg. Fix King County dmaId (819 had 0 events; 385 is the real Seattle-Tacoma DMA covering Puget Sound).

On the frontend, show the selected city in the page heading, move the area selector inline with the "Pick an area" sentence, center the whole header block, and drop the now-redundant Clear date button from the date-filter bar.